### PR TITLE
fix: add missing import for `os` in test/test_geneval.py

### DIFF
--- a/test/test_geneval.py
+++ b/test/test_geneval.py
@@ -5,6 +5,7 @@ import pickle
 import glob
 import tqdm
 from concurrent.futures import ThreadPoolExecutor
+import os
 
 BATCH_SIZE = 24
 


### PR DESCRIPTION
The `os` module is used in line 11 of `test/test_geneval.py` but was not imported, causing a runtime error. This PR adds the missing `import os`.
